### PR TITLE
Multiple Writers

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Here are all the variables that can be changed:
 | ----------------- | ------------------------------------------------------------------------------------ | ---------------------- | ---------------- |
 | `NormalOut`       | The output file for Debug, Success, Warning, and Info                                | `os.Stdout`            | `*os.File`       |
 | `ErrOut`          | The output file for Fatal and Error                                                  | `os.Stderr`            | `*os.File`       |
+| `ExtraNormalOuts` | Extra normal output destinations (e.g. outputting to a file as well as stdout)       | `[]io.Writer{}`        | `[]io.Writer`    |
+| `ExtraErrOuts`    | Extra error output destinations (e.g. outputting to a file as well as stderr)        | `[]io.Writer{}`        | `[]io.Writer`    |
 | `ExitCode`        | Fatal exit code                                                                      | `1`                    | `int`            |
 | `Padding`         | If the log should have an extra new line at the bottom                               | `false`                | `bool`           |
 | `ColoredOutput`   | If the output should have color                                                      | `true`                 | `bool`           |

--- a/custom.go
+++ b/custom.go
@@ -28,6 +28,8 @@ func NewCustomLogger() Logger {
 	config := Logger{}
 	config.NormalOut = os.Stdout
 	config.ErrOut = os.Stderr
+	config.ExtraNormalOuts = []io.Writer{}
+	config.ExtraErrOuts = []io.Writer{}
 	config.ExitCode = 1
 	config.ShowStack = true
 	config.Timezone = time.UTC

--- a/custom.go
+++ b/custom.go
@@ -1,21 +1,24 @@
 package lumber
 
 import (
+	"io"
 	"os"
 	"time"
 )
 
 // Custom logger for lumber to use
 type Logger struct {
-	NormalOut     *os.File       // The output file for Debug, Success, Warning, and Info. Default is os.Stdout
-	ErrOut        *os.File       // The output file for Fatal, FatalMsg, Error, and ErrorMsg. Default is os.Stderr
-	ExitCode      int            // Fatal exit code. Default is 1
-	ShowStack     bool           // If stack trades should be included. Default is true
-	Timezone      *time.Location // Timezone for the time to be outputted in. Default is time.UTC
-	Padding       bool           // If the log should have an extra new line at the bottom. Default is true
-	Multiline     bool           // If the log should span multiple lines. Default is false
-	ColoredOutput bool           // If the output should have color. Default is true
-	TrueColor     bool           // If the output should be true color or basic colors. Default is true if the terminal supports it
+	NormalOut       *os.File       // The output file for Debug, Success, Warning, and Info. Default is os.Stdout
+	ErrOut          *os.File       // The output file for Fatal, FatalMsg, Error, and ErrorMsg. Default is os.Stderr
+	ExtraNormalOuts []io.Writer    // Extra normal output destinations (e.g. outputting to a file as well)
+	ExtraErrOuts    []io.Writer    // Extra error output destinations (e.g. outputting to a file as well)
+	ExitCode        int            // Fatal exit code. Default is 1
+	ShowStack       bool           // If stack trades should be included. Default is true
+	Timezone        *time.Location // Timezone for the time to be outputted in. Default is time.UTC
+	Padding         bool           // If the log should have an extra new line at the bottom. Default is true
+	Multiline       bool           // If the log should span multiple lines. Default is false
+	ColoredOutput   bool           // If the output should have color. Default is true
+	TrueColor       bool           // If the output should be true color or basic colors. Default is true if the terminal supports it
 }
 
 // Default value for true color

--- a/log.go
+++ b/log.go
@@ -2,6 +2,7 @@ package lumber
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -24,7 +25,8 @@ var defaultLogger = NewCustomLogger()
 // Log a normal status (Debug, Success, Warning, and Info)
 func logNormal(config Logger, stat string, t time.Time, ctx ...interface{}) {
 	out := format(config, stat, t, separateWithSpaces(ctx...))
-	log.New(config.NormalOut, "", 0).Println(out)
+	writers := append([]io.Writer{config.NormalOut}, config.ExtraNormalOuts...)
+	log.New(io.MultiWriter(writers...), "", 0).Println(out)
 }
 
 // Log a normal status (Debug, Success, Warning, and Info)
@@ -48,7 +50,8 @@ func logError(config Logger, stat string, t time.Time, err error, ctx ...interfa
 		out = format(config, stat, t, separateWithSpaces(ctx...)+"\n\n"+err.Error())
 	}
 
-	log.New(config.ErrOut, "", 0).Println(out)
+	writers := append([]io.Writer{config.ErrOut}, config.ExtraErrOuts...)
+	log.New(io.MultiWriter(writers...), "", 0).Println(out)
 }
 
 // Output a success log


### PR DESCRIPTION
## Description

New `Logger` structs for outputting to extra `io.Writer`s (one for normal logs and one for error logs).

## Steps

- [x] My change requires a change to the documentation
- [x] I have updated the accessible documentation according
- [x] I have read the **CONTRIBUTING.md** file
- [x] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

This PR resolves #8